### PR TITLE
Re-added Spotify API wrapper as a dependency, refactored login to use the API wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pg": "^6.1.0",
     "querystring": "~0.2.0",
     "request": "~2.34.0",
-    "socket.io": "^1.5.1"
+    "socket.io": "^1.5.1",
+    "spotify-web-api-node": "^2.3.6"
   }
 }


### PR DESCRIPTION
 -The wrapper is installed as a Node package from npm, spotify-web-api-node

 -It turns out that this API wrapper does have a function for getting a
  user's top artists, it just was marked as 'TBD' in the set of examples
  on the GitHub repo for the package, which was somewhat misleading

 -See https://github.com/thelinmichael/spotify-web-api-node
  for more details on the API wrapper
